### PR TITLE
allow user to specify num_workers for dataloader

### DIFF
--- a/eigenpro/solver.py
+++ b/eigenpro/solver.py
@@ -18,7 +18,7 @@ def fit(model, X, Y, x, y, device, dtype=torch.float32, kernel=None,
         n_data_pcd_nyst_samples=3_000, n_model_pcd_nyst_samples=3_000,
         n_data_pcd_eigenvals=150, n_model_pcd_eigenvals =150,
         tmp_centers_coeff=2, wandb=None, T=None, epochs=1,
-        accumulated_gradients=True):
+        accumulated_gradients=True, num_workers=1):
     """Fit a kernel model using EigenPro method.
 
     Args:
@@ -41,6 +41,7 @@ def fit(model, X, Y, x, y, device, dtype=torch.float32, kernel=None,
         epochs(int): number of epochs to run over the training samples
         accumulated_gradients: It should be true if Z and X are different, but if they are the same set this to False
                                for faster convergence.
+        num_workers(int): how many subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
 
     Returns:
         model(object): the trained model will be returned
@@ -143,7 +144,7 @@ def fit(model, X, Y, x, y, device, dtype=torch.float32, kernel=None,
 
 
             if wandb is not None:
-                loss_test, accu_test = metrics.get_performance(model, x, y)
+                loss_test, accu_test = metrics.get_performance(model, x, y, num_workers=num_workers)
                 wandb.log({'test loss': loss_test.item(),
                            'test accuracy': accu_test})
 
@@ -152,7 +153,7 @@ def fit(model, X, Y, x, y, device, dtype=torch.float32, kernel=None,
             torch.cuda.synchronize()
             torch.cuda.empty_cache()
 
-        loss_test, accu_test = metrics.get_performance(model, x, y)
+        loss_test, accu_test = metrics.get_performance(model, x, y, num_workers=num_workers)
         # Print epoch summary using tabulate
         epoch_summary = [
             ["Test Loss", f"{loss_test:.10f}"],

--- a/eigenpro/utils/metrics.py
+++ b/eigenpro/utils/metrics.py
@@ -1,13 +1,14 @@
 import torch
 
 
-def get_performance(model, X, Y, batch_size=1024):
+def get_performance(model, X, Y, batch_size=1024, num_workers=1):
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
     # Ensure model is in evaluation mode
     # Convert X and Y to PyTorch datasets and use DataLoader for batch processing
     dataset = torch.utils.data.TensorDataset(X, Y)
-    dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=1)
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size,
+                                             shuffle=False, num_workers=num_workers)
 
     total_loss = 0
     total_accuracy = 0


### PR DESCRIPTION
On some platforms (e.g. Google Colab) I am running into some hard-to-debug issue with spawning new subprocesses. In this case I'd like to disable this by setting the num_workers for the data loader.