### PR TITLE
fix deprecated kwarg in scipy.eigh

### DIFF
--- a/eigenpro/utils/eigh.py
+++ b/eigenpro/utils/eigh.py
@@ -97,7 +97,7 @@ def top_q_eig(matrix: torch.Tensor, q: int) -> EigenSystem:
 
     n_sample = matrix.shape[0]
     eigenvalues, eigenvectors = sp.linalg.eigh(
-        matrix, eigvals=(n_sample - q-1, n_sample - 1))
+        matrix, subset_by_index=(n_sample - q-1, n_sample - 1))
     eigenvalues = torch.from_numpy(np.flip(eigenvalues).copy()).to(device)
     eigenvectors = torch.from_numpy(np.fliplr(eigenvectors).copy()).to(device)
 


### PR DESCRIPTION
Fixes a bug -- currently the call to scipy.eigh uses the 'eigvals' kwarg which has been deprecated and removed. See https://docs.scipy.org/doc/scipy-1.10.1/reference/generated/scipy.linalg.eigh.html